### PR TITLE
docs: remove stale unpublished path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ surya-yantra/
 │   ├── web/                  # Next.js 14 Web App (Vercel)
 │   │   ├── app/              # App Router pages
 │   │   ├── components/       # UI components
+│   │   ├── hooks/            # Client-side data hooks
 │   │   ├── lib/              # Business logic
-│   │   └── prisma/           # Database schema
+│   │   ├── prisma/           # Database schema
+│   │   └── __tests__/        # Vitest test setup
 │   └── desktop/              # Electron standalone app
-├── packages/
-│   ├── scpi-client/          # ESL-Solar SCPI driver
-│   ├── iv-engine/            # IEC 60891 correction engine
-│   └── types/                # Shared TypeScript types
+│       ├── electron/         # Main + preload processes
+│       └── shared/           # Desktop-only shared notes
 ├── hardware/
-│   ├── schematics/           # SVG circuit diagrams
 │   ├── BOM.md                # Complete Bill of Materials
-│   └── WIRING.md             # Wiring guide
+│   └── (additional setup docs planned)
 └── docs/
-    ├── PRD.md                # Product Requirements
     ├── API.md                # API Reference
+    ├── DEPLOYMENT.md         # Vercel deployment runbook
+    ├── HARDWARE-SETUP.md     # Rack, wiring, and commissioning guide
     └── IEC-CORRECTIONS.md    # Standards implementation
 ```
 
@@ -165,11 +165,8 @@ IAM(θ) = 1 - exp(-cos(θ)/ar) / (1 - exp(-1/ar))
 
 See [`hardware/BOM.md`](hardware/BOM.md) for complete Bill of Materials with online purchase links.
 
-See [`hardware/schematics/`](hardware/schematics/) for:
-- System overview schematic
-- MUX relay matrix wiring
-- 4-wire Kelvin connection detail
-- 19" rack layout drawing
+See [`docs/HARDWARE-SETUP.md`](docs/HARDWARE-SETUP.md) for the published rack layout,
+Kelvin wiring, relay-matrix overview, and commissioning checklist.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -115,14 +115,16 @@ If any call returns 5xx check **Deployments → Functions → Logs**.
 ## 8. Hardware connectivity
 
 The lab's ESL-Solar 500 and MUX matrix are **not** reachable from Vercel
-directly. Deploy the lightweight relay service (`apps/desktop/relay`) on
-a lab PC and expose it to the internet via:
+directly. Run a small lab-side gateway on a PC inside the rack network and
+expose it to the internet via:
 
 * **Cloudflare Tunnel** (recommended, free, no inbound firewall)
 * **Tailscale Funnel** (simple, uses your tailnet)
 * **ngrok** (fastest to set up, paid plan for persistent URLs)
 
-The web app then hits `MUX_DRIVER_URL` which points at the tunnel endpoint.
+The web app then hits `MUX_DRIVER_URL`, which should point at that tunnel
+endpoint. The gateway implementation is deployment-specific and is not
+published in this repository yet.
 
 ---
 

--- a/docs/HARDWARE-SETUP.md
+++ b/docs/HARDWARE-SETUP.md
@@ -129,8 +129,9 @@ Lab PC ──USB── Modbus RTU ──► MUX controller (STM32H7) ──►
              I²C I/O expanders (MCP23017, 18×) ──► relay coils (24 V DC)
 ```
 
-The controller firmware lives in `hardware/firmware/mux-controller/` (not in
-this documentation repo yet).
+The controller firmware is managed outside this repository. Keep the Modbus
+map and safety interlocks in sync with the deployed controller build used by
+the lab.
 
 ### 4.3 Wiring terminal blocks
 


### PR DESCRIPTION
## Summary
- align the repository structure section with the files that are actually published
- replace hardware and deployment references to unpublished paths with accurate guidance
- point hardware readers to the existing setup guide instead of missing schematic paths

## Testing
- `git diff --check`
- `rg -n 'packages/|hardware/schematics|WIRING.md|PRD.md|apps/desktop/relay|hardware/firmware/mux-controller/' README.md docs/DEPLOYMENT.md docs/HARDWARE-SETUP.md`

Closes #132.
