### PR TITLE
docs: add tracked web env example

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,18 @@
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/surya_yantra
+DIRECT_URL=postgresql://user:password@localhost:5432/surya_yantra
+
+# Auth
+NEXTAUTH_SECRET=<run: openssl rand -base64 32>
+NEXTAUTH_URL=http://localhost:3000
+
+# AI
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-... # optional
+
+# Hardware (leave blank for pure web / no lab hardware)
+ESL_SOLAR_HOST=192.168.1.40
+MUX_DRIVER_URL=https://mux.srishti.local
+
+# Logging
+LOG_LEVEL=info

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -50,8 +50,12 @@ In **Project Settings → Environment Variables** add:
 | `MUX_DRIVER_URL`        | Production         | `https://mux.srishti.local`             |
 | `LOG_LEVEL`             | All                | `info`                                  |
 
-**Never** commit the actual values — `.env.local` and `apps/web/.env*` are
-gitignored.
+For local setup, copy `apps/web/.env.example` to `apps/web/.env.local` and
+fill in real values there.
+
+**Never** commit the actual values. `.env.local` and other private `.env.*`
+files are gitignored, while `apps/web/.env.example` stays committed as the
+tracked template.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a committed `apps/web/.env.example` that matches the deployment env table
- keep the Quick Start `cp apps/web/.env.example apps/web/.env.local` path working on a clean clone
- clarify in the deployment guide that `.env.example` stays tracked while private `.env.local` values remain ignored

Closes #146.

## Validation
- `cp apps/web/.env.example apps/web/.env.local`
- verified the keys in `apps/web/.env.example` match the `docs/DEPLOYMENT.md` env table exactly
